### PR TITLE
Form Rendering from Template, Form Persistence and Routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.3.0",
     "@material-ui/core": "^4.11.2",
+    "@material-ui/data-grid": "^4.0.0-alpha.14",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@testing-library/jest-dom": "^5.11.4",

--- a/server/app.py
+++ b/server/app.py
@@ -3,7 +3,12 @@ import os
 from flask import Flask, request
 from flask_cors import CORS
 from middleware.registration import check_user_registration, verify_registration
-from middleware.form_template_handler import add_new_template
+from middleware.form_template_handler import (
+    add_new_template,
+    fetch_all_templates,
+    submit_form_response,
+    fetch_template_metadata_by_course,
+)
 
 # Flask app setup
 app = Flask(__name__)
@@ -30,6 +35,20 @@ def register():
 def add_template():
     template_data = request.get_json(force=True)
     return add_new_template(template_data), 200
+
+@app.route('/all_templates')
+def get_all_templates():
+    return fetch_all_templates(), 200
+
+@app.route('/template_metadata')
+def get_templates_by_course():
+    course = request.args.get('course')
+    return fetch_template_metadata_by_course(course), 200
+
+@app.route('/submit_response', methods=['POST'])
+def submit_response():
+    response_data = request.get_json(force=True)
+    return submit_form_response(response_data), 200
 
 if __name__ == '__main__':
     app.run(host="127.0.0.1", port="5000")

--- a/server/database/routes.py
+++ b/server/database/routes.py
@@ -39,5 +39,9 @@ class Database(object):
     def templates(self):
         return self.client.core_data['templates']
 
+    @property
+    def form_responses(self):
+        return self.client.core_data['form_responses']
+
 
 db = Database()

--- a/server/middleware/form_template_handler.py
+++ b/server/middleware/form_template_handler.py
@@ -3,10 +3,34 @@ from database.routes import db
 def add_new_template(template):
     template = dict(template)
     db.templates.update_one(
-        {'email': template.get('email'), 'course': template.get('course')},
+        {
+            'email': template.get('email'),
+            'course': template.get('course'),
+            'formName': template.get('formName')
+        },
         {
             '$set': template
         },
         upsert=True
     )
+    return {'success': True}
+
+def fetch_all_templates():
+    templates = list(db.templates.find({}))
+    for template in templates:
+        template.pop("_id", None)
+    return {'templates': templates}
+
+def fetch_template_metadata_by_course(course):
+    metadata = list(db.templates.find({'course': course}))
+    for entry in metadata:
+        entry.pop('_id', None)
+        entry.pop('template', None)
+        formName = entry['formName']
+        responseCount = db.form_responses.find({'formName': formName}).count()
+        entry['count'] = responseCount
+    return {'metadata': metadata}
+
+def submit_form_response(response):
+    db.form_responses.insert_one(dict(response))
     return {'success': True}

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,54 @@
+import * as React from "react";
 import {BrowseView} from "./BrowseView"
-import {BrowserRouter} from "react-router-dom";
+import {BrowserRouter, Switch, Route} from "react-router-dom";
+import ApiManager from "./api/api";
+import {FormTemplateView} from "./FormTemplateView";
 
-function App() {
-  return (
+class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      allTemplates: null,
+    };
+  }
+
+  componentDidMount() {
+    ApiManager.get("/all_templates").then((response) => {
+      const templates = response.data["templates"];
+      const allTemplates = (
+        <Switch>
+          <Route path="/" exact={true} key={"index"} render={() => <BrowseView />} />
+          {templates.map((template, index) => {
+            const formName = template["formName"].toLowerCase();
+            const formCourse = template["course"].toLowerCase().split(" ")[1];
+            const formPath = `/${formCourse}/${formName.replaceAll(" ", "-")}`;
+            return (
+              <Route 
+                path={formPath}
+                exact={true}
+                key={`${formCourse}-${index}`}
+                render={() => <FormTemplateView template={template} />}
+              />
+            );
+          })}
+        </Switch>
+      );
+      this.setState({allTemplates});
+    })
+  }
+  
+
+  render() {
+    const allTemplates = this.state.allTemplates;
+    return (
       <BrowserRouter>
         <div className="App">
-          <BrowseView />
+          {allTemplates ? allTemplates : <div></div>}
         </div>
       </BrowserRouter>
-  );
+    );
+  }
+  
 }
 
 export default App;
-
-

--- a/src/BrowseView.jsx
+++ b/src/BrowseView.jsx
@@ -15,11 +15,18 @@ import {
 } from "@material-ui/core";
 import {Menu, CheckCircleRounded, ErrorRounded, NoteAddRounded} from "@material-ui/icons";
 import { Autocomplete, Alert } from "@material-ui/lab";
+import { DataGrid } from "@material-ui/data-grid";
 import { FormCreationView } from "./FormCreationView";
 import ApiManager from "./api/api";
 import {GoogleLogin, GoogleLogout} from "react-google-login";
-import { courses } from "./data/utils";
+import { courses, getFormPath } from "./data/utils";
 
+const formMetadataColumns = [
+    { field: "name", headerName: "Author", width: 200 },
+    { field: "formName", headerName: "Form Name", width: 300 },
+    { field: "count", headerName: "# Responses", width: 150 },
+    { field: "url", headerName: "Published Url", width: 400 },
+];
 
 class BrowseView extends React.Component {
     constructor(props) {
@@ -38,6 +45,7 @@ class BrowseView extends React.Component {
             registrationError: "",
             isInitialized: false,
             showNewFormTemplate: false,
+            formMetadata: [],
         };
     }
 
@@ -50,6 +58,7 @@ class BrowseView extends React.Component {
             const isInitialized = true;
             this.setState({isUserRegistered, isInitialized});
         });
+        this.fetchAllCourseFormMetadata();
     }
 
     registerUser = () => {
@@ -147,6 +156,19 @@ class BrowseView extends React.Component {
                 </>
             );
         }
+    }
+
+    fetchAllCourseFormMetadata = () => {
+        // fetches the metadata of all the published forms for the current course
+        ApiManager.get("/template_metadata", {course: this.state.course}).then((response) => {
+            const metadata = response.data["metadata"]
+            console.log("Received response from /template_metadata", metadata);
+            metadata.forEach((row, index) => {
+                row["url"] = getFormPath(row["formName"], row["course"]);
+                row["id"] = index;
+            })
+            this.setState({formMetadata: metadata});
+        });
     }
 
     renderBrowseViewMainContainer = () => {
@@ -247,8 +269,8 @@ class BrowseView extends React.Component {
                         Registration Success!
                     </Alert>
                 </Snackbar>
-                <div>
-                    TODO: Add in Form Data Here
+                <div style={{ width: "100%", height: "800px"}}>
+                    <DataGrid rows={this.state.formMetadata} columns={formMetadataColumns} pageSize={20} />
                 </div>
             </>
         );

--- a/src/FormCreationView.jsx
+++ b/src/FormCreationView.jsx
@@ -24,6 +24,7 @@ import {
     CancelRounded,
 } from "@material-ui/icons";
 import ApiManager from "./api/api";
+import {getFormPath} from "./data/utils";
 
 const qType = Object.freeze({
     shortAnswer: "short-answer",
@@ -199,7 +200,8 @@ export class FormCreationView extends React.Component {
             name: this.props.name,
             email: this.props.email,
             course: this.props.course,
-            template: this.state.template
+            template: this.state.template,
+            formName: this.state.formName,
         };
         ApiManager.post('/new_template', templateData).then((response) => {
             const data = response.data;
@@ -210,16 +212,20 @@ export class FormCreationView extends React.Component {
     }
 
     render() {
+        const formName = this.state.formName ? this.state.formName : "";
+        const course = this.props.course ? this.props.course : "";
         return (
             <>
                 <Snackbar
                     open={this.state.showFormCreationSuccess}
-                    autoHideDuration={5000}
+                    autoHideDuration={8000}
                     onClose={() => this.setState({showFormCreationSuccess: false})}
                     anchorOrigin={{vertical: "top", horizontal: "center"}}
                 >
                     <Alert severity="success" icon={<CheckCircleRounded />}>
-                        Form Successfully Published!
+                        Form Successfully Published! <br />
+                        Your form is published at path {getFormPath(formName, course)}. <br />
+                        Please refresh this page to finalize the publishing process.
                     </Alert>
                 </Snackbar>
                 <FormGroup>

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -1,3 +1,11 @@
 const courses = ["CS 61A", "CS 61B", "CS 61C", "CS 70", "CS 160", "CS 161", "CS 162", "CS 164", "CS 169A", "CS 170", "CS 186", "CS 188", "CS 189"];
+const clientBaseUrl = "localhost:8887";
 
-export { courses };
+const getFormPath = (formName, formCourse) => {
+    formName = formName.toLowerCase();
+    formCourse = formCourse.toLowerCase().split(" ")[1];
+    return `${clientBaseUrl}/${formCourse}/${formName.replaceAll(" ", "-")}`;
+}
+
+
+export { courses, clientBaseUrl, getFormPath };


### PR DESCRIPTION
In this PR,
- Support is added for rendering the actual form students will use to submit their answers based on a template pre-selected by a TA. The template will be dynamically generated and added to match a given route based on the form name and course number.
- The main browsing page of the team builder website is provided with a data grid containing all the forms related to the course. At the current stage of development, it contains the following fields: author, form name, # submitted responses, and the published Url

Here're some screenshots illustrating the usage:
The first screenshot illustrates the data grid.
The second screenshot illustrates the dynamically rendered form based on a template;
<img width="1787" alt="Screen Shot 2021-01-01 at 9 10 29 PM" src="https://user-images.githubusercontent.com/31458840/103449408-02195a80-4c76-11eb-86a8-2bbe3f416c8c.png">
<img width="1764" alt="Screen Shot 2021-01-01 at 9 10 59 PM" src="https://user-images.githubusercontent.com/31458840/103449410-047bb480-4c76-11eb-9f30-b568390f786b.png">
