### PR TITLE
initial draft of re-editing form

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@testing-library/user-event": "^12.1.10",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "ag-grid-community": "^25.0.0",
+    "ag-grid-react": "^25.0.0",
     "antd": "^4.9.4",
     "axios": "^0.21.1",
     "react": "^17.0.1",
@@ -21,6 +23,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "typescript": "^4.1.3",
+    "uuid": "^8.3.2",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/server/middleware/form_template_handler.py
+++ b/server/middleware/form_template_handler.py
@@ -1,12 +1,11 @@
 from database.routes import db
 
+
 def add_new_template(template):
     template = dict(template)
     db.templates.update_one(
         {
-            'email': template.get('email'),
-            'course': template.get('course'),
-            'formName': template.get('formName')
+            'formId': template.get('formId')
         },
         {
             '$set': template
@@ -15,21 +14,24 @@ def add_new_template(template):
     )
     return {'success': True}
 
+
 def fetch_all_templates():
     templates = list(db.templates.find({}))
     for template in templates:
         template.pop("_id", None)
     return {'templates': templates}
 
+
 def fetch_template_metadata_by_course(course):
     metadata = list(db.templates.find({'course': course}))
     for entry in metadata:
         entry.pop('_id', None)
         entry.pop('template', None)
-        formName = entry['formName']
-        responseCount = db.form_responses.find({'formName': formName}).count()
+        formId = entry['formId']
+        responseCount = db.form_responses.find({'formId': formId}).count()
         entry['count'] = responseCount
     return {'metadata': metadata}
+
 
 def submit_form_response(response):
     db.form_responses.insert_one(dict(response))

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,17 @@ class App extends React.Component {
                   path={editPath}
                   exact={true}
                   key={`${formId}-edit`}
-                  render={(props) => <FormUpdateView {...props} template={template["template"]} formName={formName} formId={formId} course={course}/>}
+                  render={
+                    (props) => 
+                      <FormUpdateView 
+                        {...props} 
+                        template={template["template"]} 
+                        formName={formName} 
+                        formUrl={formUrl}
+                        formId={formId} 
+                        course={course}
+                      />
+                  }
                 />
               </>
             );

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import {BrowseView} from "./BrowseView"
 import {BrowserRouter, Switch, Route} from "react-router-dom";
 import ApiManager from "./api/api";
 import {FormTemplateView} from "./FormTemplateView";
+import {FormUpdateView} from "./FormUpdateView";
+import {getFormPath} from "./data/utils";
 
 class App extends React.Component {
   constructor(props) {
@@ -17,18 +19,26 @@ class App extends React.Component {
       const templates = response.data["templates"];
       const allTemplates = (
         <Switch>
-          <Route path="/" exact={true} key={"index"} render={() => <BrowseView />} />
+          <Route path="/" exact={true} key="index" render={() => <BrowseView />} />
           {templates.map((template, index) => {
-            const formName = template["formName"].toLowerCase();
-            const formCourse = template["course"].toLowerCase().split(" ")[1];
-            const formPath = `/${formCourse}/${formName.replaceAll(" ", "-")}`;
+            const {formName, course, formUrl, formId} = template;
+            const formPath = getFormPath(formName, course, formUrl, true);
+            const editPath = `${formPath}/edit`;
             return (
-              <Route 
-                path={formPath}
-                exact={true}
-                key={`${formCourse}-${index}`}
-                render={() => <FormTemplateView template={template} />}
-              />
+              <>
+                <Route
+                  path={formPath}
+                  exact={true}
+                  key={formId}
+                  render={() => <FormTemplateView template={template} />}
+                />
+                <Route
+                  path={editPath}
+                  exact={true}
+                  key={`${formId}-edit`}
+                  render={(props) => <FormUpdateView {...props} template={template["template"]} formName={formName} formId={formId} course={course}/>}
+                />
+              </>
             );
           })}
         </Switch>

--- a/src/BrowseView.jsx
+++ b/src/BrowseView.jsx
@@ -15,18 +15,11 @@ import {
 } from "@material-ui/core";
 import {Menu, CheckCircleRounded, ErrorRounded, NoteAddRounded} from "@material-ui/icons";
 import { Autocomplete, Alert } from "@material-ui/lab";
-import { DataGrid } from "@material-ui/data-grid";
 import { FormCreationView } from "./FormCreationView";
+import FormMetadataGridView from "./FormMetadataGridView";
 import ApiManager from "./api/api";
 import {GoogleLogin, GoogleLogout} from "react-google-login";
 import { courses, getFormPath } from "./data/utils";
-
-const formMetadataColumns = [
-    { field: "name", headerName: "Author", width: 200 },
-    { field: "formName", headerName: "Form Name", width: 300 },
-    { field: "count", headerName: "# Responses", width: 150 },
-    { field: "url", headerName: "Published Url", width: 400 },
-];
 
 class BrowseView extends React.Component {
     constructor(props) {
@@ -56,6 +49,8 @@ class BrowseView extends React.Component {
             console.log("Received response from user registration check", response.data);
             const isUserRegistered = response.data["is_registered"];
             const isInitialized = true;
+            localStorage.setItem("isRegistered", isUserRegistered);
+            localStorage.setItem("username", this.state.name);
             this.setState({isUserRegistered, isInitialized});
         });
         this.fetchAllCourseFormMetadata();
@@ -164,7 +159,7 @@ class BrowseView extends React.Component {
             const metadata = response.data["metadata"]
             console.log("Received response from /template_metadata", metadata);
             metadata.forEach((row, index) => {
-                row["url"] = getFormPath(row["formName"], row["course"]);
+                row["url"] = getFormPath(row["formName"], row["course"], row["formUrl"]);
                 row["id"] = index;
             })
             this.setState({formMetadata: metadata});
@@ -270,7 +265,11 @@ class BrowseView extends React.Component {
                     </Alert>
                 </Snackbar>
                 <div style={{ width: "100%", height: "800px"}}>
-                    <DataGrid rows={this.state.formMetadata} columns={formMetadataColumns} pageSize={20} />
+                    <FormMetadataGridView
+                        rowData={this.state.formMetadata}
+                        isRegistered={this.state.isUserRegistered}
+                        username={this.state.name}
+                    />
                 </div>
             </>
         );

--- a/src/FormCreationView.jsx
+++ b/src/FormCreationView.jsx
@@ -299,7 +299,7 @@ export class FormCreationView extends React.Component {
                             error={this.checkFormNameCollision()}
                             helperText={
                                 this.checkFormNameCollision() 
-                                    ? "The form name already exists. By default, any changes you make will update the original form." 
+                                    ? "The form name already exists. By default, unless a new url path is specified below, any changes you make will update the original form." 
                                     : ""
                             }
                             value={this.state.formName}

--- a/src/FormCreationView.jsx
+++ b/src/FormCreationView.jsx
@@ -54,12 +54,12 @@ export class FormCreationView extends React.Component {
     }
 
     componentDidMount() {
-        const {formName, template} = this.props;
+        const {formName, formUrl, template} = this.props;
         if (formName && template) {
             const submitButtonName = "Update Form";
             const formPublishMessage = "Form Successfully Updated!"
             // If form name and the template have been predefined, the form is being edited
-            this.setState({formName, template, submitButtonName, formPublishMessage});
+            this.setState({formName, formUrl, template, submitButtonName, formPublishMessage});
         }
         this.fetchAllFormMetadata();
     }

--- a/src/FormEditRenderer.jsx
+++ b/src/FormEditRenderer.jsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import {IconButton, Typography} from "@material-ui/core";
+import {UpdateOutlined} from "@material-ui/icons";
+import {Link} from "react-router-dom";
+
+
+export class FormEditRenderer extends React.Component {
+    getFormEditLink = () => {
+        return this.props.context.componentParent.getFormEditLink(this.props.node);
+    }
+
+    getUser = () => {
+        return this.props.context.componentParent.getUser();
+    }
+
+    checkIsRegistered = () => {
+        return this.props.context.componentParent.checkIsRegistered();
+    }
+
+    render() {
+        return (
+            <Link
+                to={{pathname: this.getFormEditLink()}}
+                target="_blank"
+            >
+                Edit Form
+            </Link>
+        );
+    }
+}

--- a/src/FormMetadataGridView.jsx
+++ b/src/FormMetadataGridView.jsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { withRouter } from "react-router-dom";
+import { AgGridReact } from "ag-grid-react";
+import { FormEditRenderer } from "./FormEditRenderer";
+import "ag-grid-community/dist/styles/ag-grid.css";
+import "ag-grid-community/dist/styles/ag-theme-balham.css";
+
+const formMetadataColumns = [
+    { field: "name", headerName: "Author", width: 200 },
+    { field: "formName", headerName: "Form Name", width: 300 },
+    { field: "count", headerName: "# Responses", width: 150 },
+    { field: "url", headerName: "Published Url", width: 300 },
+    { field: "url", headerName: "Edit Form", cellRenderer: "formEditRenderer"},
+];
+
+const formMetadataColDefs = {
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+}
+
+const formFrameworkComponents = {
+    formEditRenderer: FormEditRenderer,
+};
+
+class FormMetadataGridView extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            context: {componentParent: this},
+        };
+    }
+
+    onGridReady = (params) => {
+        this.gridApi = params.api;
+        this.gridColumnApi = params.columnApi;
+    }
+
+    getFormEditLink = (node) => {
+        console.log("node", node);
+        const formUrl = node.data.url;
+        return `${formUrl.substring(formUrl.indexOf("/") + 1)}/edit`;
+    }
+
+    getUser = () => {
+        return this.props.username;
+    }
+
+    checkIsRegistered = () => {
+        return this.props.isRegistered;
+    }
+
+    render() {
+        return (
+            <div
+                className="ag-theme-balham"
+                style={{height: "100%", width: "100%"}}
+            >
+                <AgGridReact
+                    enableCellTextSelection={true}
+                    columnDefs={formMetadataColumns}
+                    defaultColDef={formMetadataColDefs}
+                    rowData={this.props.rowData}
+                    context={this.state.context}
+                    onGridReady={this.onGridReady}
+                    frameworkComponents={formFrameworkComponents}
+                />
+            </div>
+        );
+    }
+}
+
+export default withRouter(FormMetadataGridView);

--- a/src/FormTemplateView.jsx
+++ b/src/FormTemplateView.jsx
@@ -31,6 +31,7 @@ export class FormTemplateView extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            formId: "",
             formName: "",
             course: "",
             data: {},
@@ -40,22 +41,22 @@ export class FormTemplateView extends React.Component {
         };
     }
 
-    handleSingleValueChange = (event, type, prompt) => {
+    handleSingleValueChange = (event, prompt) => {
         let data = this.state.data;
-        data[type][prompt] = event.target.value;
+        data[prompt] = event.target.value;
         this.setState({data});
     }
     
     handleMultiValueChange = (event, type, prompt) => {
         let data = this.state.data;
-        let selections = data[type][prompt];
+        let selections = data[prompt];
         let currOption = event.target.name;
         if (selections.includes(currOption)) {
             selections = selections.filter((o) => o !== currOption);
         } else {
             selections.push(currOption);
         }
-        data[type][prompt] = selections;
+        data[prompt] = selections;
         this.setState({data});
     }
 
@@ -70,8 +71,8 @@ export class FormTemplateView extends React.Component {
                         label="Answer"
                         variant="outlined"
                         required={true}
-                        value={this.state.data[type][prompt]}
-                        onChange={(event) => this.handleSingleValueChange(event, type, prompt)}
+                        value={this.state.data[prompt]}
+                        onChange={(event) => this.handleSingleValueChange(event, prompt)}
                         fullWidth={true}
                         style={{marginTop: "10pt", marginBottom: "10pt"}}
                     />
@@ -79,7 +80,7 @@ export class FormTemplateView extends React.Component {
                 break;
             case qType.singleSelect:
                 body = (
-                    <RadioGroup value={this.state.data[type][prompt]} onChange={(event) => this.handleSingleValueChange(event, type, prompt)}>
+                    <RadioGroup value={this.state.data[prompt]} onChange={(event) => this.handleSingleValueChange(event, prompt)}>
                         {options.map((option) => {
                             return (
                                 <FormControlLabel
@@ -100,7 +101,7 @@ export class FormTemplateView extends React.Component {
                                 <FormControlLabel
                                     control={
                                         <Checkbox 
-                                            checked={this.state.data[type][prompt].includes(option)} 
+                                            checked={this.state.data[prompt].includes(option)}
                                             onChange={(event) => this.handleMultiValueChange(event, type, prompt)} 
                                             name={option} 
                                         />
@@ -127,23 +128,20 @@ export class FormTemplateView extends React.Component {
         let response = [];
         const data = this.state.data;
         let allFilledOut = true;
-        for (var qType in data) {
-            for (var q in data[qType]) {
-                let ans = data[qType][q];
-                if (typeof ans === "string" && ans.trim().length === 0) {
-                    allFilledOut = false;
-                } else if (Array.isArray(ans) && ans.length === 0){
-                    allFilledOut = false;
-                }
-                if (!allFilledOut) {
-                    this.setState({showMissingFieldError: true});
-                    return;
-                }
-                response.push(ans);
+        for (const ans in Object.values(data)) {
+            if (typeof ans === "string" && ans.trim().length === 0) {
+                allFilledOut = false;
+            } else if (Array.isArray(ans) && ans.length === 0){
+                allFilledOut = false;
             }
+            if (!allFilledOut) {
+                this.setState({showMissingFieldError: true});
+                return;
+            }
+            response.push(ans);
         }
         const formData = {
-            formName: this.state.formName,
+            formId: this.state.formId,
             response: response,
         };
         ApiManager.post('/submit_response', formData).then((response) => {
@@ -186,21 +184,19 @@ export class FormTemplateView extends React.Component {
 
     mountFormState = (template) => {
         const data = {};
-        for (var t in qType) {
-            data[qType[t]] = {};
-        }
         const course = template["course"];
+        const formId = template["formId"];
         const formName = template["formName"];
         template = template["template"];
         template.forEach(question => {
             const {type, prompt} = question;
             if ([qType.shortAnswer, qType.singleSelect].includes(type)) {
-                data[type][prompt] = "";
+                data[prompt] = "";
             } else {
-                data[type][prompt] = [];
+                data[prompt] = [];
             }
         });
-        this.setState({data, template, formName, course});
+        this.setState({data, template, formId, formName, course});
     }
 
     componentDidMount() {

--- a/src/FormUpdateView.jsx
+++ b/src/FormUpdateView.jsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import {FormCreationView} from "./FormCreationView";
+import {Toolbar, AppBar, IconButton, Typography, Box} from "@material-ui/core";
+import {Menu} from "@material-ui/icons";
+
+export class FormUpdateView extends React.Component {
+    render() {
+        const user = localStorage.getItem("username");
+        const isRegistered = localStorage.getItem("isRegistered");
+        const {template, formName, formId, course} = this.props;
+        return (
+            <div style={{flexGrow: 1}}>
+                <AppBar position="static" variant="outlined" color="primary">
+                    <Toolbar>
+                        <IconButton edge="start">
+                            <Menu />
+                        </IconButton>
+                        <Typography variant="h6" style={{flexGrow: 1}}>
+                            Team Builder - Updating a Form
+                        </Typography>
+                        <Typography variant="h6">
+                            Welcome {user}!
+                        </Typography>
+                    </Toolbar>
+                </AppBar>
+                <Box
+                    style={{
+                        justifyContent: "center",
+                        display: "flex",
+                        alignItems: "center",
+                        padding: "5pt",
+                    }}
+                >
+                    {isRegistered
+                        ?
+                        <FormCreationView template={template} formName={formName} formId={formId} course={course} />
+                        :
+                        <Typography>
+                            Direct access has been disabled.
+                            Please sign in as a registered TA for the course and then update the form from the main page.
+                        </Typography>
+                    }
+                </Box>
+            </div>
+        );
+    }
+}

--- a/src/FormUpdateView.jsx
+++ b/src/FormUpdateView.jsx
@@ -7,7 +7,7 @@ export class FormUpdateView extends React.Component {
     render() {
         const user = localStorage.getItem("username");
         const isRegistered = localStorage.getItem("isRegistered");
-        const {template, formName, formId, course} = this.props;
+        const {template, formName, formId, formUrl, course} = this.props;
         return (
             <div style={{flexGrow: 1}}>
                 <AppBar position="static" variant="outlined" color="primary">
@@ -33,7 +33,13 @@ export class FormUpdateView extends React.Component {
                 >
                     {isRegistered
                         ?
-                        <FormCreationView template={template} formName={formName} formId={formId} course={course} />
+                        <FormCreationView 
+                            template={template} 
+                            formName={formName} 
+                            formId={formId} 
+                            formUrl={formUrl}
+                            course={course} 
+                        />
                         :
                         <Typography>
                             Direct access has been disabled.

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -1,10 +1,12 @@
 const courses = ["CS 61A", "CS 61B", "CS 61C", "CS 70", "CS 160", "CS 161", "CS 162", "CS 164", "CS 169A", "CS 170", "CS 186", "CS 188", "CS 189"];
 const clientBaseUrl = "localhost:8887";
 
-const getFormPath = (formName, formCourse) => {
+const getFormPath = (formName, formCourse, formUrl="", withoutBase=false) => {
     formName = formName.toLowerCase();
     formCourse = formCourse.toLowerCase().split(" ")[1];
-    return `${clientBaseUrl}/${formCourse}/${formName.replaceAll(" ", "-")}`;
+    formUrl = formUrl.trim();
+    const formPath = formUrl.length === 0 ? `${formCourse}/${formName.replaceAll(" ", "-")}` : `${formCourse}/${formUrl}`;
+    return withoutBase ? `/${formPath}` : `${clientBaseUrl}/${formPath}`;
 }
 
 


### PR DESCRIPTION
Feature: Form Re-editing and Custom Url:
- In this PR, an uuid is introduced for each form template a registered user creates; this helps quick identification and supports modification of an existing form after it has been published.
- Url override is now introduced to give users the freedom of creating a custom sub-url path instead of the default one generated from the form name. Proper checks are also added on the client-side to enforce a non-empty form name.
- Display of all form metadata associated with the course is now handled by the package react-ag-grid instead of the data grid from materials-ui. react-ag-grid allows more customization and provides finer control over individual cell components.
- Direct access to a particular form edit page is blocked for un-registered users in case students accidentally run into it. 
- Validation of form names and urls to prevent accidental collision (unless intended for direct updates). Preview of url link based on name and path is also added.


**Video Demo:**
https://user-images.githubusercontent.com/31458840/104226804-5e1e7480-5416-11eb-9583-29bc57c3d33a.mp4