### PR TITLE
Grid-based Ranking and Visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-google-login": "^5.2.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
+    "recharts": "^2.0.0",
     "typescript": "^4.1.3",
     "uuid": "^8.3.2",
     "web-vitals": "^0.2.4"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@testing-library/user-event": "^12.1.10",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "ag-grid-community": "^25.0.0",
+    "ag-grid-react": "^25.0.0",
     "antd": "^4.9.4",
     "axios": "^0.21.1",
     "react": "^17.0.1",
@@ -21,6 +23,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "typescript": "^4.1.3",
+    "uuid": "^8.3.2",
     "web-vitals": "^0.2.4"
   },
   "scripts": {

--- a/server/app.py
+++ b/server/app.py
@@ -8,6 +8,7 @@ from middleware.form_template_handler import (
     fetch_all_templates,
     submit_form_response,
     fetch_template_metadata_by_course,
+    aggregate_form_responses,
 )
 
 # Flask app setup
@@ -49,6 +50,11 @@ def get_templates_by_course():
 def submit_response():
     response_data = request.get_json(force=True)
     return submit_form_response(response_data), 200
+
+@app.route('/aggregate_response')
+def get_aggregated_responses():
+    form_id = request.args.get('formId')
+    return aggregate_form_responses(form_id), 200
 
 if __name__ == '__main__':
     app.run(host="127.0.0.1", port="5000")

--- a/server/middleware/form_template_handler.py
+++ b/server/middleware/form_template_handler.py
@@ -1,5 +1,10 @@
 from database.routes import db
+from enum import Enum, unique
 
+class QuestionType(str, Enum):
+    SHORT_ANSWER = 'short-answer'
+    SINGLE_SELECT = 'single-select'
+    MULTI_SELECT = 'multi-select'
 
 def add_new_template(template):
     template = dict(template)
@@ -32,7 +37,86 @@ def fetch_template_metadata_by_course(course):
         entry['count'] = responseCount
     return {'metadata': metadata}
 
-
 def submit_form_response(response):
     db.form_responses.insert_one(dict(response))
     return {'success': True}
+
+def construct_form_response_column_defs(headers, types):
+    column_defs = []
+    field_names = []
+    field_names_to_headers = {}
+    header_to_field_names = {}
+    field_names_to_types = {}
+    for idx, header in enumerate(headers):
+        field_name = header.replace(' ', '_').lower()
+        field_names.append(field_name)
+        field_names_to_headers[field_name] = header
+        header_to_field_names[header] = field_name
+        field_names_to_types[field_name] = types[idx]
+        column_defs.append({
+            'field': field_name,
+            'headerName': header,
+            'width': 200,
+        })
+    return field_names, column_defs, field_names_to_types, field_names_to_headers, header_to_field_names
+
+def match_form_responses_to_fields(submissions, header_to_field_names):
+    field_responses = []
+    for submission in submissions:
+        response = submission['response']
+        matched_response = {}
+        for header in header_to_field_names:
+            if header in response:
+                matched_response[header_to_field_names[header]] = response[header]
+            else:
+                matched_response[header_to_field_names[header]] = 'NA'
+        field_responses.append(matched_response)
+    return field_responses 
+
+def add_if_not_exists(d, field):
+    if field not in d:
+        d[field] = 0
+    d[field] += 1
+
+def aggregate_form_responses_by_fields(form_responses, field_names, field_names_to_types, field_names_to_headers):
+    aggregated_result = {}
+    for field_name in field_names:
+        if not field_names_to_types[field_name] == QuestionType.SHORT_ANSWER:
+            aggregated_result[field_name] = {}
+            aggregated_result[field_name]['title'] = field_names_to_headers[field_name]
+            aggregated_result[field_name]['data'] = []
+            data = aggregated_result[field_name]['data']
+            freq = {}
+            for form_response in form_responses:
+                response = form_response[field_name]
+                if isinstance(response, str):
+                    add_if_not_exists(freq, response)
+                else:
+                    # Handles when multiple options are chosen for multiselect
+                    for individual_choice in response:
+                        add_if_not_exists(freq, individual_choice)
+            for option, count in freq.items():
+                data.append({
+                    'name': option,
+                    'value': count
+                })
+    return aggregated_result
+
+def aggregate_form_responses(form_id):
+    # TODO: once SID + name verification are in place with the roster upload,
+    # mark each submission as unique and traceable for the student
+    submissions = db.form_responses.find({'formId': form_id})
+    metadata = db.templates.find_one({'formId': form_id})
+    if metadata:
+        template = metadata['template']
+        prompts = [q['prompt'] for q in template]
+        types = [q['type'] for q in template]
+        field_names, column_defs, field_names_to_types, field_names_to_headers, header_to_field_names = construct_form_response_column_defs(prompts, types)
+        form_responses = match_form_responses_to_fields(submissions, header_to_field_names)
+        aggregated_responses = aggregate_form_responses_by_fields(
+            form_responses, field_names, field_names_to_types, field_names_to_headers)
+        return {
+            'grid_responses': form_responses,
+            'grid_column_defs': column_defs,
+            'aggregated_responses': aggregated_responses
+        }

--- a/server/middleware/form_template_handler.py
+++ b/server/middleware/form_template_handler.py
@@ -1,12 +1,11 @@
 from database.routes import db
 
+
 def add_new_template(template):
     template = dict(template)
     db.templates.update_one(
         {
-            'email': template.get('email'),
-            'course': template.get('course'),
-            'formName': template.get('formName')
+            'formId': template.get('formId')
         },
         {
             '$set': template
@@ -15,21 +14,24 @@ def add_new_template(template):
     )
     return {'success': True}
 
+
 def fetch_all_templates():
     templates = list(db.templates.find({}))
     for template in templates:
         template.pop("_id", None)
     return {'templates': templates}
 
+
 def fetch_template_metadata_by_course(course):
     metadata = list(db.templates.find({'course': course}))
     for entry in metadata:
         entry.pop('_id', None)
         entry.pop('template', None)
-        formName = entry['formName']
-        responseCount = db.form_responses.find({'formName': formName}).count()
+        formId = entry['formId']
+        responseCount = db.form_responses.find({'formId': formId}).count()
         entry['count'] = responseCount
     return {'metadata': metadata}
+
 
 def submit_form_response(response):
     db.form_responses.insert_one(dict(response))

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,17 @@ class App extends React.Component {
                   path={editPath}
                   exact={true}
                   key={`${formId}-edit`}
-                  render={(props) => <FormUpdateView {...props} template={template["template"]} formName={formName} formId={formId} course={course}/>}
+                  render={
+                    (props) => 
+                      <FormUpdateView 
+                        {...props} 
+                        template={template["template"]} 
+                        formName={formName} 
+                        formUrl={formUrl}
+                        formId={formId} 
+                        course={course}
+                      />
+                  }
                 />
               </>
             );

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import {BrowserRouter, Switch, Route} from "react-router-dom";
 import ApiManager from "./api/api";
 import {FormTemplateView} from "./FormTemplateView";
 import {FormUpdateView} from "./FormUpdateView";
+import {FormResponseSummaryView} from "./FormResponseSummaryView";
 import {getFormPath} from "./data/utils";
 
 class App extends React.Component {
@@ -24,6 +25,7 @@ class App extends React.Component {
             const {formName, course, formUrl, formId} = template;
             const formPath = getFormPath(formName, course, formUrl, true);
             const editPath = `${formPath}/edit`;
+            const vizPath = `${formPath}/viz`;
             return (
               <>
                 <Route
@@ -45,6 +47,19 @@ class App extends React.Component {
                         formUrl={formUrl}
                         formId={formId} 
                         course={course}
+                      />
+                  }
+                />
+                <Route
+                  path={vizPath}
+                  exact={true}
+                  key={`${formId}-viz`}
+                  render={
+                    (props) => 
+                      <FormResponseSummaryView
+                        {...props}
+                        formName={formName}
+                        formId={formId}
                       />
                   }
                 />

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import {BrowseView} from "./BrowseView"
 import {BrowserRouter, Switch, Route} from "react-router-dom";
 import ApiManager from "./api/api";
 import {FormTemplateView} from "./FormTemplateView";
+import {FormUpdateView} from "./FormUpdateView";
+import {getFormPath} from "./data/utils";
 
 class App extends React.Component {
   constructor(props) {
@@ -17,18 +19,26 @@ class App extends React.Component {
       const templates = response.data["templates"];
       const allTemplates = (
         <Switch>
-          <Route path="/" exact={true} key={"index"} render={() => <BrowseView />} />
+          <Route path="/" exact={true} key="index" render={() => <BrowseView />} />
           {templates.map((template, index) => {
-            const formName = template["formName"].toLowerCase();
-            const formCourse = template["course"].toLowerCase().split(" ")[1];
-            const formPath = `/${formCourse}/${formName.replaceAll(" ", "-")}`;
+            const {formName, course, formUrl, formId} = template;
+            const formPath = getFormPath(formName, course, formUrl, true);
+            const editPath = `${formPath}/edit`;
             return (
-              <Route 
-                path={formPath}
-                exact={true}
-                key={`${formCourse}-${index}`}
-                render={() => <FormTemplateView template={template} />}
-              />
+              <>
+                <Route
+                  path={formPath}
+                  exact={true}
+                  key={formId}
+                  render={() => <FormTemplateView template={template} />}
+                />
+                <Route
+                  path={editPath}
+                  exact={true}
+                  key={`${formId}-edit`}
+                  render={(props) => <FormUpdateView {...props} template={template["template"]} formName={formName} formId={formId} course={course}/>}
+                />
+              </>
             );
           })}
         </Switch>

--- a/src/BrowseView.jsx
+++ b/src/BrowseView.jsx
@@ -15,18 +15,11 @@ import {
 } from "@material-ui/core";
 import {Menu, CheckCircleRounded, ErrorRounded, NoteAddRounded} from "@material-ui/icons";
 import { Autocomplete, Alert } from "@material-ui/lab";
-import { DataGrid } from "@material-ui/data-grid";
 import { FormCreationView } from "./FormCreationView";
+import FormMetadataGridView from "./FormMetadataGridView";
 import ApiManager from "./api/api";
 import {GoogleLogin, GoogleLogout} from "react-google-login";
 import { courses, getFormPath } from "./data/utils";
-
-const formMetadataColumns = [
-    { field: "name", headerName: "Author", width: 200 },
-    { field: "formName", headerName: "Form Name", width: 300 },
-    { field: "count", headerName: "# Responses", width: 150 },
-    { field: "url", headerName: "Published Url", width: 400 },
-];
 
 class BrowseView extends React.Component {
     constructor(props) {
@@ -56,6 +49,8 @@ class BrowseView extends React.Component {
             console.log("Received response from user registration check", response.data);
             const isUserRegistered = response.data["is_registered"];
             const isInitialized = true;
+            localStorage.setItem("isRegistered", isUserRegistered);
+            localStorage.setItem("username", this.state.name);
             this.setState({isUserRegistered, isInitialized});
         });
         this.fetchAllCourseFormMetadata();
@@ -164,7 +159,7 @@ class BrowseView extends React.Component {
             const metadata = response.data["metadata"]
             console.log("Received response from /template_metadata", metadata);
             metadata.forEach((row, index) => {
-                row["url"] = getFormPath(row["formName"], row["course"]);
+                row["url"] = getFormPath(row["formName"], row["course"], row["formUrl"]);
                 row["id"] = index;
             })
             this.setState({formMetadata: metadata});
@@ -270,7 +265,11 @@ class BrowseView extends React.Component {
                     </Alert>
                 </Snackbar>
                 <div style={{ width: "100%", height: "800px"}}>
-                    <DataGrid rows={this.state.formMetadata} columns={formMetadataColumns} pageSize={20} />
+                    <FormMetadataGridView
+                        rowData={this.state.formMetadata}
+                        isRegistered={this.state.isUserRegistered}
+                        username={this.state.name}
+                    />
                 </div>
             </>
         );

--- a/src/FormCreationView.jsx
+++ b/src/FormCreationView.jsx
@@ -299,7 +299,7 @@ export class FormCreationView extends React.Component {
                             error={this.checkFormNameCollision()}
                             helperText={
                                 this.checkFormNameCollision() 
-                                    ? "The form name already exists. By default, any changes you make will update the original form." 
+                                    ? "The form name already exists. By default, unless a new url path is specified below, any changes you make will update the original form." 
                                     : ""
                             }
                             value={this.state.formName}

--- a/src/FormCreationView.jsx
+++ b/src/FormCreationView.jsx
@@ -54,12 +54,12 @@ export class FormCreationView extends React.Component {
     }
 
     componentDidMount() {
-        const {formName, template} = this.props;
+        const {formName, formUrl, template} = this.props;
         if (formName && template) {
             const submitButtonName = "Update Form";
             const formPublishMessage = "Form Successfully Updated!"
             // If form name and the template have been predefined, the form is being edited
-            this.setState({formName, template, submitButtonName, formPublishMessage});
+            this.setState({formName, formUrl, template, submitButtonName, formPublishMessage});
         }
         this.fetchAllFormMetadata();
     }

--- a/src/FormEditRenderer.jsx
+++ b/src/FormEditRenderer.jsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import {IconButton, Typography} from "@material-ui/core";
+import {UpdateOutlined} from "@material-ui/icons";
+import {Link} from "react-router-dom";
+
+
+export class FormEditRenderer extends React.Component {
+    getFormEditLink = () => {
+        return this.props.context.componentParent.getFormEditLink(this.props.node);
+    }
+
+    getUser = () => {
+        return this.props.context.componentParent.getUser();
+    }
+
+    checkIsRegistered = () => {
+        return this.props.context.componentParent.checkIsRegistered();
+    }
+
+    render() {
+        return (
+            <Link
+                to={{pathname: this.getFormEditLink()}}
+                target="_blank"
+            >
+                Edit Form
+            </Link>
+        );
+    }
+}

--- a/src/FormEditRenderer.jsx
+++ b/src/FormEditRenderer.jsx
@@ -1,20 +1,11 @@
 import * as React from "react";
-import {IconButton, Typography} from "@material-ui/core";
-import {UpdateOutlined} from "@material-ui/icons";
 import {Link} from "react-router-dom";
+import {FormAccessType} from "./data/utils";
 
 
 export class FormEditRenderer extends React.Component {
     getFormEditLink = () => {
-        return this.props.context.componentParent.getFormEditLink(this.props.node);
-    }
-
-    getUser = () => {
-        return this.props.context.componentParent.getUser();
-    }
-
-    checkIsRegistered = () => {
-        return this.props.context.componentParent.checkIsRegistered();
+        return this.props.context.componentParent.getLink(this.props.node, FormAccessType.EDIT);
     }
 
     render() {

--- a/src/FormMetadataGridView.jsx
+++ b/src/FormMetadataGridView.jsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { withRouter } from "react-router-dom";
 import { AgGridReact } from "ag-grid-react";
 import { FormEditRenderer } from "./FormEditRenderer";
+import { FormResponseVizRenderer } from "./FormResponseVizRenderer";
+import { FormAccessType } from "./data/utils";
 import "ag-grid-community/dist/styles/ag-grid.css";
 import "ag-grid-community/dist/styles/ag-theme-balham.css";
 
@@ -11,6 +13,7 @@ const formMetadataColumns = [
     { field: "count", headerName: "# Responses", width: 150 },
     { field: "url", headerName: "Published Url", width: 300 },
     { field: "url", headerName: "Edit Form", cellRenderer: "formEditRenderer"},
+    { field: "url", headerName: "Response Summary", cellRenderer: "formResponseVizRenderer"},
 ];
 
 const formMetadataColDefs = {
@@ -23,6 +26,7 @@ const formMetadataColDefs = {
 
 const formFrameworkComponents = {
     formEditRenderer: FormEditRenderer,
+    formResponseVizRenderer: FormResponseVizRenderer,
 };
 
 class FormMetadataGridView extends React.Component {
@@ -38,25 +42,25 @@ class FormMetadataGridView extends React.Component {
         this.gridColumnApi = params.columnApi;
     }
 
-    getFormEditLink = (node) => {
+    getLink = (node, type) => {
         console.log("node", node);
         const formUrl = node.data.url;
-        return `${formUrl.substring(formUrl.indexOf("/") + 1)}/edit`;
-    }
-
-    getUser = () => {
-        return this.props.username;
-    }
-
-    checkIsRegistered = () => {
-        return this.props.isRegistered;
+        const partialUrl = formUrl.substring(formUrl.indexOf("/") + 1);
+        switch (type) {
+            case FormAccessType.EDIT:
+                return `${partialUrl}/edit`;
+            case FormAccessType.VISUALIZE:
+                return `${partialUrl}/viz`;
+            default:
+                return "";
+        }
     }
 
     render() {
         return (
             <div
                 className="ag-theme-balham"
-                style={{height: "100%", width: "100%"}}
+                style={{height: "800pt", width: "100%"}}
             >
                 <AgGridReact
                     enableCellTextSelection={true}

--- a/src/FormMetadataGridView.jsx
+++ b/src/FormMetadataGridView.jsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { withRouter } from "react-router-dom";
+import { AgGridReact } from "ag-grid-react";
+import { FormEditRenderer } from "./FormEditRenderer";
+import "ag-grid-community/dist/styles/ag-grid.css";
+import "ag-grid-community/dist/styles/ag-theme-balham.css";
+
+const formMetadataColumns = [
+    { field: "name", headerName: "Author", width: 200 },
+    { field: "formName", headerName: "Form Name", width: 300 },
+    { field: "count", headerName: "# Responses", width: 150 },
+    { field: "url", headerName: "Published Url", width: 300 },
+    { field: "url", headerName: "Edit Form", cellRenderer: "formEditRenderer"},
+];
+
+const formMetadataColDefs = {
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+}
+
+const formFrameworkComponents = {
+    formEditRenderer: FormEditRenderer,
+};
+
+class FormMetadataGridView extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            context: {componentParent: this},
+        };
+    }
+
+    onGridReady = (params) => {
+        this.gridApi = params.api;
+        this.gridColumnApi = params.columnApi;
+    }
+
+    getFormEditLink = (node) => {
+        console.log("node", node);
+        const formUrl = node.data.url;
+        return `${formUrl.substring(formUrl.indexOf("/") + 1)}/edit`;
+    }
+
+    getUser = () => {
+        return this.props.username;
+    }
+
+    checkIsRegistered = () => {
+        return this.props.isRegistered;
+    }
+
+    render() {
+        return (
+            <div
+                className="ag-theme-balham"
+                style={{height: "100%", width: "100%"}}
+            >
+                <AgGridReact
+                    enableCellTextSelection={true}
+                    columnDefs={formMetadataColumns}
+                    defaultColDef={formMetadataColDefs}
+                    rowData={this.props.rowData}
+                    context={this.state.context}
+                    onGridReady={this.onGridReady}
+                    frameworkComponents={formFrameworkComponents}
+                />
+            </div>
+        );
+    }
+}
+
+export default withRouter(FormMetadataGridView);

--- a/src/FormResponseDataGridView.jsx
+++ b/src/FormResponseDataGridView.jsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import {Typography} from "@material-ui/core";
+import { AgGridReact } from "ag-grid-react";
+import "ag-grid-community/dist/styles/ag-grid.css";
+import "ag-grid-community/dist/styles/ag-theme-balham.css";
+
+const formMetadataColDefs = {
+    sortable: true,
+    flex: 1,
+    minWidth: 100,
+    filter: true,
+    resizable: true,
+}
+
+export class FormResponseDataGridView extends React.Component {
+    onGridReady = (params) => {
+        this.gridApi = params.api;
+        this.gridColumnApi = params.columnApi;
+    }
+
+    render() {
+        return (
+            <>
+                <Typography variant="h6">All Responses</Typography>
+                <div
+                    className="ag-theme-balham"
+                    style={{height: "200pt", width: "100%"}}
+                >
+                    <AgGridReact
+                        enableCellTextSelection={true}
+                        columnDefs={this.props.columnDefs}
+                        defaultColDef={formMetadataColDefs}
+                        rowData={this.props.rowData}
+                        onGridReady={this.onGridReady}
+                    />
+                </div>
+            </>
+        );
+    }
+}

--- a/src/FormResponseHistogramView.jsx
+++ b/src/FormResponseHistogramView.jsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import {Typography, Divider} from "@material-ui/core";
+import * as Recharts from "recharts/umd/Recharts";
+
+const {BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip} = Recharts;
+
+  export class FormResponseHistogramView extends React.Component {
+
+      renderHistograms = (agg) => {
+          console.log("agg", agg);
+          return (
+              <> 
+                <Typography variant="h6">Bar Charts</Typography>
+                {
+                    agg.map((question) => {
+                        return (
+                            <div style={{display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center"}}>
+                                <Typography><b>Question</b>: {question["title"]}</Typography>
+                                <BarChart
+                                    width={800}
+                                    height={400}
+                                    data={question["data"]}
+                                    margin={{
+                                        top: 5, right: 10, left: 10, bottom: 5
+                                    }}
+                                >
+                                    <CartesianGrid strokeDasharray="3 3" />
+                                    <XAxis dataKey="name" />
+                                    <YAxis />
+                                    <Tooltip />
+                                    <Bar dataKey="value" fill="#8884d8" />
+                                </BarChart>
+                                <Divider style={{margin: "10pt"}}/>
+                                <br />
+                            </div>
+                        );
+                    })
+                }
+              </>
+          );
+      }
+
+      render() {
+          return this.renderHistograms(Object.values(this.props.aggregatedResponses));
+      }
+  }

--- a/src/FormResponseSummaryView.jsx
+++ b/src/FormResponseSummaryView.jsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import {Toolbar, AppBar, IconButton, Typography, Box, Divider} from "@material-ui/core";
+import {BarChart} from "@material-ui/icons";
+import {FormResponseDataGridView} from "./FormResponseDataGridView";
+import {FormResponseHistogramView} from "./FormResponseHistogramView";
+import ApiManager from "./api/api.js";
+
+export class FormResponseSummaryView extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            gridData: [],
+            columnDefs: [],
+            aggregatedResponses: {},
+        };
+    }
+
+    componentDidMount = () => {
+        const params = {formId: this.props.formId};
+        ApiManager.get("/aggregate_response", params).then((response) => {
+            const data = response.data;
+            console.log("Received responses from /aggregate_response", data);
+            const gridData = "grid_responses" in data ? data["grid_responses"] : [];
+            const columnDefs = "grid_column_defs" in data ? data["grid_column_defs"] : [];
+            const aggregatedResponses = "aggregated_responses" in data ? data["aggregated_responses"] : {};
+            this.setState({gridData, columnDefs, aggregatedResponses});
+        })
+    }
+
+    renderVizTabs = () => {
+        return (
+            <>
+                <FormResponseDataGridView columnDefs={this.state.columnDefs} rowData={this.state.gridData} />
+                <Divider style={{margin: "10pt"}} />
+                <FormResponseHistogramView aggregatedResponses={this.state.aggregatedResponses} />
+            </>
+        );
+    }
+
+    render() {
+        const user = localStorage.getItem("username");
+        const isRegistered = localStorage.getItem("isRegistered");
+        return (
+            <div>
+                <AppBar position="static" variant="outlined" color="primary">
+                    <Toolbar>
+                        <IconButton edge="start">
+                            <BarChart />
+                        </IconButton>
+                        <Typography variant="h6" style={{flexGrow: 1}}>
+                            Team Builder - Response Summary for Form: {this.props.formName}
+                        </Typography>
+                        <Typography variant="h6">
+                            Welcome {user}!
+                        </Typography>
+                    </Toolbar>
+                </AppBar>
+                <div
+                    style={{
+                        justifyContent: "center",
+                        alignItems: "center",
+                        padding: "5pt",
+                    }}
+                >
+                    {isRegistered
+                        ?
+                        this.renderVizTabs()
+                        :
+                        <Typography>
+                            Direct access has been disabled.
+                            Please sign in as a registered TA for the course and then update the form from the main page.
+                        </Typography>
+                    }
+                </div>
+            </div>
+        );
+    }
+}

--- a/src/FormResponseVizRenderer.jsx
+++ b/src/FormResponseVizRenderer.jsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import {Link} from "react-router-dom";
+import {FormAccessType} from "./data/utils";
+
+
+export class FormResponseVizRenderer extends React.Component {
+    getFormResponseVizLink = () => {
+        return this.props.context.componentParent.getLink(this.props.node, FormAccessType.VISUALIZE);
+    }
+
+    render() {
+        return (
+            <Link
+                to={{pathname: this.getFormResponseVizLink()}}
+                target="_blank"
+            >
+                View Response Summary
+            </Link>
+        );
+    }
+}

--- a/src/FormTemplateView.jsx
+++ b/src/FormTemplateView.jsx
@@ -31,6 +31,7 @@ export class FormTemplateView extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            formId: "",
             formName: "",
             course: "",
             data: {},
@@ -40,22 +41,22 @@ export class FormTemplateView extends React.Component {
         };
     }
 
-    handleSingleValueChange = (event, type, prompt) => {
+    handleSingleValueChange = (event, prompt) => {
         let data = this.state.data;
-        data[type][prompt] = event.target.value;
+        data[prompt] = event.target.value;
         this.setState({data});
     }
     
     handleMultiValueChange = (event, type, prompt) => {
         let data = this.state.data;
-        let selections = data[type][prompt];
+        let selections = data[prompt];
         let currOption = event.target.name;
         if (selections.includes(currOption)) {
             selections = selections.filter((o) => o !== currOption);
         } else {
             selections.push(currOption);
         }
-        data[type][prompt] = selections;
+        data[prompt] = selections;
         this.setState({data});
     }
 
@@ -70,8 +71,8 @@ export class FormTemplateView extends React.Component {
                         label="Answer"
                         variant="outlined"
                         required={true}
-                        value={this.state.data[type][prompt]}
-                        onChange={(event) => this.handleSingleValueChange(event, type, prompt)}
+                        value={this.state.data[prompt]}
+                        onChange={(event) => this.handleSingleValueChange(event, prompt)}
                         fullWidth={true}
                         style={{marginTop: "10pt", marginBottom: "10pt"}}
                     />
@@ -79,7 +80,7 @@ export class FormTemplateView extends React.Component {
                 break;
             case qType.singleSelect:
                 body = (
-                    <RadioGroup value={this.state.data[type][prompt]} onChange={(event) => this.handleSingleValueChange(event, type, prompt)}>
+                    <RadioGroup value={this.state.data[prompt]} onChange={(event) => this.handleSingleValueChange(event, prompt)}>
                         {options.map((option) => {
                             return (
                                 <FormControlLabel
@@ -100,7 +101,7 @@ export class FormTemplateView extends React.Component {
                                 <FormControlLabel
                                     control={
                                         <Checkbox 
-                                            checked={this.state.data[type][prompt].includes(option)} 
+                                            checked={this.state.data[prompt].includes(option)}
                                             onChange={(event) => this.handleMultiValueChange(event, type, prompt)} 
                                             name={option} 
                                         />
@@ -127,23 +128,20 @@ export class FormTemplateView extends React.Component {
         let response = [];
         const data = this.state.data;
         let allFilledOut = true;
-        for (var qType in data) {
-            for (var q in data[qType]) {
-                let ans = data[qType][q];
-                if (typeof ans === "string" && ans.trim().length === 0) {
-                    allFilledOut = false;
-                } else if (Array.isArray(ans) && ans.length === 0){
-                    allFilledOut = false;
-                }
-                if (!allFilledOut) {
-                    this.setState({showMissingFieldError: true});
-                    return;
-                }
-                response.push(ans);
+        for (const ans in Object.values(data)) {
+            if (typeof ans === "string" && ans.trim().length === 0) {
+                allFilledOut = false;
+            } else if (Array.isArray(ans) && ans.length === 0){
+                allFilledOut = false;
             }
+            if (!allFilledOut) {
+                this.setState({showMissingFieldError: true});
+                return;
+            }
+            response.push(ans);
         }
         const formData = {
-            formName: this.state.formName,
+            formId: this.state.formId,
             response: response,
         };
         ApiManager.post('/submit_response', formData).then((response) => {
@@ -186,21 +184,19 @@ export class FormTemplateView extends React.Component {
 
     mountFormState = (template) => {
         const data = {};
-        for (var t in qType) {
-            data[qType[t]] = {};
-        }
         const course = template["course"];
+        const formId = template["formId"];
         const formName = template["formName"];
         template = template["template"];
         template.forEach(question => {
             const {type, prompt} = question;
             if ([qType.shortAnswer, qType.singleSelect].includes(type)) {
-                data[type][prompt] = "";
+                data[prompt] = "";
             } else {
-                data[type][prompt] = [];
+                data[prompt] = [];
             }
         });
-        this.setState({data, template, formName, course});
+        this.setState({data, template, formId, formName, course});
     }
 
     componentDidMount() {

--- a/src/FormTemplateView.jsx
+++ b/src/FormTemplateView.jsx
@@ -125,10 +125,9 @@ export class FormTemplateView extends React.Component {
     submitFormResponse = () => {
         // First checks that all required fields are non-empty.
         // TODO: enable optional fields; for now, all fields are mandatory.
-        let response = [];
         const data = this.state.data;
         let allFilledOut = true;
-        for (const ans in Object.values(data)) {
+        for (const [_, ans] of Object.entries(data)) {
             if (typeof ans === "string" && ans.trim().length === 0) {
                 allFilledOut = false;
             } else if (Array.isArray(ans) && ans.length === 0){
@@ -138,11 +137,10 @@ export class FormTemplateView extends React.Component {
                 this.setState({showMissingFieldError: true});
                 return;
             }
-            response.push(ans);
         }
         const formData = {
             formId: this.state.formId,
-            response: response,
+            response: data,
         };
         ApiManager.post('/submit_response', formData).then((response) => {
             const data = response.data;

--- a/src/FormUpdateView.jsx
+++ b/src/FormUpdateView.jsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import {FormCreationView} from "./FormCreationView";
+import {Toolbar, AppBar, IconButton, Typography, Box} from "@material-ui/core";
+import {Menu} from "@material-ui/icons";
+
+export class FormUpdateView extends React.Component {
+    render() {
+        const user = localStorage.getItem("username");
+        const isRegistered = localStorage.getItem("isRegistered");
+        const {template, formName, formId, course} = this.props;
+        return (
+            <div style={{flexGrow: 1}}>
+                <AppBar position="static" variant="outlined" color="primary">
+                    <Toolbar>
+                        <IconButton edge="start">
+                            <Menu />
+                        </IconButton>
+                        <Typography variant="h6" style={{flexGrow: 1}}>
+                            Team Builder - Updating a Form
+                        </Typography>
+                        <Typography variant="h6">
+                            Welcome {user}!
+                        </Typography>
+                    </Toolbar>
+                </AppBar>
+                <Box
+                    style={{
+                        justifyContent: "center",
+                        display: "flex",
+                        alignItems: "center",
+                        padding: "5pt",
+                    }}
+                >
+                    {isRegistered
+                        ?
+                        <FormCreationView template={template} formName={formName} formId={formId} course={course} />
+                        :
+                        <Typography>
+                            Direct access has been disabled.
+                            Please sign in as a registered TA for the course and then update the form from the main page.
+                        </Typography>
+                    }
+                </Box>
+            </div>
+        );
+    }
+}

--- a/src/FormUpdateView.jsx
+++ b/src/FormUpdateView.jsx
@@ -7,7 +7,7 @@ export class FormUpdateView extends React.Component {
     render() {
         const user = localStorage.getItem("username");
         const isRegistered = localStorage.getItem("isRegistered");
-        const {template, formName, formId, course} = this.props;
+        const {template, formName, formId, formUrl, course} = this.props;
         return (
             <div style={{flexGrow: 1}}>
                 <AppBar position="static" variant="outlined" color="primary">
@@ -33,7 +33,13 @@ export class FormUpdateView extends React.Component {
                 >
                     {isRegistered
                         ?
-                        <FormCreationView template={template} formName={formName} formId={formId} course={course} />
+                        <FormCreationView 
+                            template={template} 
+                            formName={formName} 
+                            formId={formId} 
+                            formUrl={formUrl}
+                            course={course} 
+                        />
                         :
                         <Typography>
                             Direct access has been disabled.

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -1,10 +1,12 @@
 const courses = ["CS 61A", "CS 61B", "CS 61C", "CS 70", "CS 160", "CS 161", "CS 162", "CS 164", "CS 169A", "CS 170", "CS 186", "CS 188", "CS 189"];
 const clientBaseUrl = "localhost:8887";
 
-const getFormPath = (formName, formCourse) => {
+const getFormPath = (formName, formCourse, formUrl="", withoutBase=false) => {
     formName = formName.toLowerCase();
     formCourse = formCourse.toLowerCase().split(" ")[1];
-    return `${clientBaseUrl}/${formCourse}/${formName.replaceAll(" ", "-")}`;
+    formUrl = formUrl.trim();
+    const formPath = formUrl.length === 0 ? `${formCourse}/${formName.replaceAll(" ", "-")}` : `${formCourse}/${formUrl}`;
+    return withoutBase ? `/${formPath}` : `${clientBaseUrl}/${formPath}`;
 }
 
 

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -9,5 +9,9 @@ const getFormPath = (formName, formCourse, formUrl="", withoutBase=false) => {
     return withoutBase ? `/${formPath}` : `${clientBaseUrl}/${formPath}`;
 }
 
+const FormAccessType = Object.freeze({
+    EDIT: "edit",
+    VISUALIZE: "viz",
+});
 
-export { courses, clientBaseUrl, getFormPath };
+export { courses, clientBaseUrl, getFormPath, FormAccessType };


### PR DESCRIPTION
In this PR,
- Grid-based ranking is added as an additional option in form-templating where the user needs to assign a unique rank (in order of preference) for each of the specified options. Proper warning and checks are added to ensure a unique rank is given to each option and all ranks must have been selected. Hue-based bar charts are provided to accommodate this form of questions.
- On the backend, the structure of response submission is improved such that an additional field is created (during the first insertion into the mongo collection, and during the send-back of the response to the frontend) to reference the actual prompts instead of directly using them as keys (which can potentially cause bson format error and make debugging a lot harder).

Here's the video demo on this particular feature:

https://user-images.githubusercontent.com/31458840/104375235-09036100-54f1-11eb-9264-53cdf1675474.mov

